### PR TITLE
Win32 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ aliases:
     - image: circleci/node:10.11
   - &restore-cache
     keys:
-      - v1-dependencies-{{ checksum "package.json" }}
+      - test-cache-v1-{{ checksum ".checksum" }}
       - v1-dependencies-
     paths:
       - ~/repo
   - &save-cache
     paths:
       - ~/repo
-    key: v1-dependencies-{{ checksum "package.json" }}
+    key: test-cache-v1-{{ checksum ".checksum" }}
 jobs:
   build:
     docker: *base-image
@@ -22,6 +22,9 @@ jobs:
     steps:
       - checkout
       - run: yarn install --frozen-lockfile
+      - run:
+          name: Create checksum
+          command: shasum ~/repo/* > ~/repo/.checksum && cat ~/repo/.checksum
       - save_cache: *save-cache
   lint:
     docker: *base-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,16 @@ aliases:
     - image: circleci/node:10.11
   - &restore-cache
     keys:
-      - test-cache-v1-{{ checksum ".checksum" }}
-      - v1-dependencies-
+      - source-v1-{{ .Branch }}-{{ .Revision }}
+      - source-v1-{{ .Branch }}-
+      - source-v1-
     paths:
       - ~/repo
   - &save-cache
     paths:
       - ~/repo
-    key: test-cache-v1-{{ checksum ".checksum" }}
+      - ".git"
+    key: source-v1-{{ .Branch }}-{{ .Revision }}
 jobs:
   build:
     docker: *base-image
@@ -22,9 +24,6 @@ jobs:
     steps:
       - checkout
       - run: yarn install --frozen-lockfile
-      - run:
-          name: Create checksum
-          command: find ./src -type f \( -exec sha1sum "$PWD"/{} \; \) > ~/repo/.checksum && cat ~/repo/.checksum
       - save_cache: *save-cache
   lint:
     docker: *base-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run:
           name: Create checksum
-          command: shasum ~/repo/* > ~/repo/.checksum && cat ~/repo/.checksum
+          command: find ./src -type f \( -exec sha1sum "$PWD"/{} \; \) > ~/repo/.checksum && cat ~/repo/.checksum
       - save_cache: *save-cache
   lint:
     docker: *base-image

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Glicky aims to solve this problem by providing a GUI for common CLI commands tha
 
 Glicky hopes that by removing the need to learn the commands necessary to execute these tasks, beginners will feel more empowered get going with the work they actually want to compete, rather than wrestling with the command line.  
 
-> ⚠️ **NOTE**: This is an **early pre-release**. There will undoubtedly be bugs but it mostly works and important features are _upcoming_. **Windows is untested** and is tentatively said to be unsupported. 
+> ⚠️ **NOTE**: This is an **early pre-release**. There will undoubtedly be bugs but it mostly works and important features are _upcoming_. **Windows is not fully supported** and there might be unforseen bugs. 
 
 ## Why would I use this?
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "dist",
     "bin"
   ],
-  "os": [
-    "!win32"
-  ],
   "engines": {
     "node": "*"
   },
@@ -29,13 +26,13 @@
     "dev:styleguide": "styleguidist server --config config/styleguide.config.js --open",
     "watch:client": "webpack-dev-server --open --config config/webpack.config.js",
     "dev:client": "yarn watch:client",
-    "build:client": "NODE_ENV=production webpack --config config/webpack.config.js -p",
+    "build:client": "cross-env NODE_ENV=production webpack --config config/webpack.config.js -p",
     "watch:server": " concurrently \"nodemon dist/server/server.bundle.js -w dist/server/server.bundle.js -q --signal SIGTERM\" \"node config/rollup.watch.js\"",
     "dev:server": "yarn killport && yarn build:server && yarn watch:server",
     "build:server": "rollup --config config/rollup.config.js",
     "build": "yarn build:client && yarn build:server",
     "dev": "concurrently \"yarn dev:server\" \"yarn dev:styleguide\" \"yarn dev:client\"",
-    "start": "yarn build:client && yarn build:server && NODE_ENV=production node dist/server/server.bundle.js",
+    "start": "yarn build:client && yarn build:server && cross-env NODE_ENV=production node dist/server/server.bundle.js",
     "lint": "eslint -c .eslintrc src/**/* bin/**/* ",
     "flow": "flow check src",
     "prepublishOnly": "yarn lint && yarn flow && yarn build"
@@ -63,6 +60,7 @@
     "clean-webpack-plugin": "^0.1.19",
     "cloc": "^2.4.0",
     "concurrently": "^3.6.1",
+    "cross-env": "^5.2.0",
     "css-loader": "^1.0.0",
     "date-fns": "^1.29.0",
     "downshift": "^3.2.2",

--- a/src/server/utils/processManager.js
+++ b/src/server/utils/processManager.js
@@ -1,6 +1,5 @@
 // @flow
 import cp, { type ChildProcess } from 'child_process';
-import execa from 'execa';
 import psTree from 'ps-tree';
 import chalk from 'chalk';
 import supportsColor from 'supports-color';
@@ -160,18 +159,17 @@ export default class ProcessManager {
             rej(err);
           });
       } else {
-        execa('taskkill /PID ' + this.pid + ' /T /F')
-          .then(() => {
-            this.executing = false;
-            this.killing = false;
-            res();
-          })
-          .catch(err => {
-            this.killing = false;
-            this.emitError(err);
+        try {
+          cp.spawnSync('taskkill', ['/PID', this.pid, '/T', '/F']);
+          this.executing = false;
+          this.killing = false;
+          res();
+        } catch (err) {
+          this.killing = false;
+          this.emitError(err);
 
-            rej(err);
-          });
+          rej(err);
+        }
       }
     });
   }

--- a/src/server/utils/processManager.js
+++ b/src/server/utils/processManager.js
@@ -160,7 +160,7 @@ export default class ProcessManager {
           });
       } else {
         try {
-          cp.spawnSync('taskkill', ['/PID', this.pid, '/T', '/F']);
+          cp.spawnSync('taskkill', ['/PID', this.pid.toString(), '/T', '/F']);
           this.executing = false;
           this.killing = false;
           res();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,6 +2830,14 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -5641,7 +5649,7 @@ is-whitespace-character@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
   integrity sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
Addresses the windows related issues in #4 . The first commit adds cross-env for environment variables because `NODE_ENV=production` does not work on windows and the second commit fixes an unknown bug which passes down invalid parameters to the `taskkill` command.