### PR TITLE
[Run Bin Scripts]: Add commands in './node_modules/.bin' to subprocess path

### DIFF
--- a/src/server/utils/index.js
+++ b/src/server/utils/index.js
@@ -6,6 +6,24 @@ export const log = (text: string) => {
   process.env.GLICKY_ENV !== 'production' && console.log(text);
 };
 
+export const isWin = () => /^win/.test(process.platform);
+
+export const getPathVariableName = (): string => {
+  if (isWin()) {
+    const variables = Object.keys(process.env);
+    let path = '';
+    for (let variable of variables) {
+      if (variable.toUpperCase() === 'PATH') {
+        path = variable;
+        break;
+      }
+    }
+    return path;
+  }
+
+  return 'PATH';
+};
+
 export const parsePackageInfo = (info: Object) => {
   const {
     description,

--- a/src/server/utils/processManager.js
+++ b/src/server/utils/processManager.js
@@ -145,7 +145,7 @@ export default class ProcessManager {
         rej();
       }
       this.killing = true;
-      if (!isWin) {
+      if (!isWin()) {
         this.psTreeKill(signal)
           .then(() => {
             this.executing = false;

--- a/src/server/utils/processManager.js
+++ b/src/server/utils/processManager.js
@@ -4,7 +4,7 @@ import psTree from 'ps-tree';
 import chalk from 'chalk';
 import supportsColor from 'supports-color';
 
-import { log } from '../utils';
+import { log, isWin, getPathVariableName } from '../utils';
 
 type EmitCode = 'data' | 'processError' | 'exit';
 type KillSignal = 'SIGKILL';
@@ -14,8 +14,6 @@ type DataObject = {|
   output: ?string,
   error: boolean
 |};
-
-const isWin = /^win/.test(process.platform);
 
 export default class ProcessManager {
   proc: ChildProcess;
@@ -179,7 +177,9 @@ export default class ProcessManager {
     if (!this.initCommand) return;
 
     const env = Object.assign({}, process.env);
-    env.Path += (isWin ? ';' : ':') + process.cwd() + '/node_modules/.bin'; // Using process.cwd until a better solution is found for (#5)
+    const pathVariableName = getPathVariableName();
+    env[pathVariableName] +=
+      (isWin ? ';' : ':') + process.cwd() + '/node_modules/.bin'; // Using process.cwd until a better solution is found for (#5)
     this.proc = cp.spawn(this.initCommand, [], {
       env: Object.assign({ FORCE_COLOR: supportsColor.level }, env),
       shell: true

--- a/src/server/utils/processManager.js
+++ b/src/server/utils/processManager.js
@@ -178,8 +178,9 @@ export default class ProcessManager {
 
     const env = Object.assign({}, process.env);
     const pathVariableName = getPathVariableName();
+    // Using process.cwd until a better solution is found for (#5)
     env[pathVariableName] +=
-      (isWin ? ';' : ':') + process.cwd() + '/node_modules/.bin'; // Using process.cwd until a better solution is found for (#5)
+      (isWin ? ';' : ':') + process.cwd() + '/node_modules/.bin';
     this.proc = cp.spawn(this.initCommand, [], {
       env: Object.assign({ FORCE_COLOR: supportsColor.level }, env),
       shell: true

--- a/src/server/utils/processManager.js
+++ b/src/server/utils/processManager.js
@@ -180,7 +180,7 @@ export default class ProcessManager {
     const pathVariableName = getPathVariableName();
     // Using process.cwd until a better solution is found for (#5)
     env[pathVariableName] +=
-      (isWin ? ';' : ':') + process.cwd() + '/node_modules/.bin';
+      (isWin() ? ';' : ':') + process.cwd() + '/node_modules/.bin';
     this.proc = cp.spawn(this.initCommand, [], {
       env: Object.assign({ FORCE_COLOR: supportsColor.level }, env),
       shell: true

--- a/src/server/utils/processManager.js
+++ b/src/server/utils/processManager.js
@@ -15,6 +15,8 @@ type DataObject = {|
   error: boolean
 |};
 
+const isWin = /^win/.test(process.platform);
+
 export default class ProcessManager {
   proc: ChildProcess;
   socket: Socket;
@@ -145,7 +147,6 @@ export default class ProcessManager {
         rej();
       }
       this.killing = true;
-      const isWin = /^win/.test(process.platform);
       if (!isWin) {
         this.psTreeKill(signal)
           .then(() => {
@@ -177,8 +178,10 @@ export default class ProcessManager {
   execute() {
     if (!this.initCommand) return;
 
+    const env = Object.assign({}, process.env);
+    env.Path += (isWin ? ';' : ':') + process.cwd() + '/node_modules/.bin'; // Using process.cwd until a better solution is found for (#5)
     this.proc = cp.spawn(this.initCommand, [], {
-      env: Object.assign({ FORCE_COLOR: supportsColor.level }, process.env),
+      env: Object.assign({ FORCE_COLOR: supportsColor.level }, env),
       shell: true
     });
 


### PR DESCRIPTION
This should allow glicky to execute package scripts like those created by `create-react-app`

![github-glicky-post-11](https://user-images.githubusercontent.com/21989345/56456725-3ba61700-6368-11e9-8b04-08d566a8da37.png)

Fixes #15 